### PR TITLE
Add epsilon config for creating adversarial examples. 

### DIFF
--- a/avod/configs/simple/pyramid_cars_with_aug_simple_adv.config
+++ b/avod/configs/simple/pyramid_cars_with_aug_simple_adv.config
@@ -90,6 +90,7 @@ model_config {
         ang_loss_weight: 1.0
     }
     is_adversarial: True
+    adv_epsilon: 0.3
 }
 
 train_config {

--- a/avod/configs/simple/test_adv.config
+++ b/avod/configs/simple/test_adv.config
@@ -91,6 +91,7 @@ model_config {
     }
 
     is_adversarial: True
+    adv_epsilon: 0.3
 }
 
 train_config {

--- a/avod/configs/simple/test_adv_clean.config
+++ b/avod/configs/simple/test_adv_clean.config
@@ -91,6 +91,7 @@ model_config {
     }
 
     is_adversarial: False
+    adv_epsilon: 0.3
 }
 
 train_config {

--- a/avod/configs/simple/test_data_adv.config
+++ b/avod/configs/simple/test_data_adv.config
@@ -91,6 +91,7 @@ model_config {
     }
     
     is_adversarial: True
+    adv_epsilon: 0.3
 }
 
 train_config {

--- a/avod/core/models/avod_model.py
+++ b/avod/core/models/avod_model.py
@@ -284,9 +284,8 @@ class AvodModel(model.DetectionModel):
                 off_value=(self._config.label_smoothing_epsilon /
                         self.dataset.num_classes))
 
-            epsilon = .3
             cls_loss = avod_loss_builder._get_cls_loss(self, mb_classifications_logits, mb_classification_gt)
-            delta = epsilon * tf.sign(tf.gradients(cls_loss, img_rois))   
+            delta = self.model_config.adv_epsilon * tf.sign(tf.gradients(cls_loss, img_rois))   
             max_val = tf.math.reduce_max(img_rois, axis=None, keepdims=False, name=None)
             img_rois = img_rois + delta[0]
             img_rois = tf.clip_by_value(img_rois, 0, max_val)         

--- a/avod/protos/model.proto
+++ b/avod/protos/model.proto
@@ -42,6 +42,8 @@ message ModelConfig {
     required LossConfig loss_config = 13;
 
     optional bool is_adversarial = 14 [default = false];
+
+    optional float adv_epsilon = 15 [default = 0.0];
 }
 
 message PathsConfig {

--- a/avod/protos/model_pb2.py
+++ b/avod/protos/model_pb2.py
@@ -20,7 +20,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   syntax='proto2',
   serialized_options=None,
   create_key=_descriptor._internal_create_key,
-  serialized_pb=b'\n\x17\x61vod/protos/model.proto\x12\x0b\x61vod.protos\x1a\x18\x61vod/protos/layers.proto\"\xa7\x04\n\x0bModelConfig\x12\x1e\n\nmodel_name\x18\x01 \x01(\t:\navod_model\x12(\n\x0f\x63heckpoint_name\x18\x02 \x01(\t:\x0f\x64\x65tection_model\x12.\n\x0cpaths_config\x18\x03 \x01(\x0b\x32\x18.avod.protos.PathsConfig\x12.\n\x0cinput_config\x18\x04 \x02(\x0b\x32\x18.avod.protos.InputConfig\x12*\n\nrpn_config\x18\x05 \x02(\x0b\x32\x16.avod.protos.RpnConfig\x12,\n\x0b\x61vod_config\x18\x06 \x02(\x0b\x32\x17.avod.protos.AvodConfig\x12\x1f\n\x17label_smoothing_epsilon\x18\x07 \x02(\x02\x12\x1b\n\x13\x65xpand_proposals_xz\x18\x08 \x02(\x02\x12\x1f\n\x17path_drop_probabilities\x18\t \x03(\x02\x12\x1c\n\x14train_on_all_samples\x18\n \x02(\x08\x12\x18\n\x10\x65val_all_samples\x18\x0b \x02(\x08\x12\x30\n\rlayers_config\x18\x0c \x02(\x0b\x32\x19.avod.protos.LayersConfig\x12,\n\x0bloss_config\x18\r \x02(\x0b\x32\x17.avod.protos.LossConfig\x12\x1d\n\x0eis_adversarial\x18\x0e \x01(\x08:\x05\x66\x61lse\"G\n\x0bPathsConfig\x12\x16\n\x0e\x63heckpoint_dir\x18\x01 \x01(\t\x12\x0e\n\x06logdir\x18\x02 \x01(\t\x12\x10\n\x08pred_dir\x18\x03 \x01(\t\"\x9e\x01\n\x0bInputConfig\x12\x17\n\nbev_dims_h\x18\x01 \x01(\x05:\x03\x37\x30\x30\x12\x17\n\nbev_dims_w\x18\x02 \x01(\x05:\x03\x38\x30\x30\x12\x14\n\tbev_depth\x18\x03 \x01(\x05:\x01\x36\x12\x17\n\nimg_dims_h\x18\x04 \x01(\x05:\x03\x34\x38\x30\x12\x18\n\nimg_dims_w\x18\x05 \x01(\x05:\x04\x31\x35\x39\x30\x12\x14\n\timg_depth\x18\x06 \x01(\x05:\x01\x33\"\x9d\x01\n\tRpnConfig\x12\"\n\x1arpn_proposal_roi_crop_size\x18\x01 \x02(\x05\x12\x19\n\x11rpn_fusion_method\x18\x02 \x02(\t\x12\x1a\n\x12rpn_train_nms_size\x18\x03 \x02(\x05\x12\x19\n\x11rpn_test_nms_size\x18\x04 \x02(\x05\x12\x1a\n\x12rpn_nms_iou_thresh\x18\x05 \x02(\x02\"\xa7\x01\n\nAvodConfig\x12#\n\x1b\x61vod_proposal_roi_crop_size\x18\x01 \x02(\x05\x12\x1f\n\x17\x61vod_positive_selection\x18\x03 \x02(\t\x12\x15\n\ravod_nms_size\x18\x04 \x02(\x05\x12\x1b\n\x13\x61vod_nms_iou_thresh\x18\x05 \x02(\x02\x12\x1f\n\x17\x61vod_box_representation\x18\x06 \x02(\t\"W\n\nLossConfig\x12\x17\n\x0freg_loss_weight\x18\x01 \x02(\x02\x12\x17\n\x0f\x61ng_loss_weight\x18\x02 \x02(\x02\x12\x17\n\x0f\x63ls_loss_weight\x18\x03 \x02(\x02'
+  serialized_pb=b'\n\x17\x61vod/protos/model.proto\x12\x0b\x61vod.protos\x1a\x18\x61vod/protos/layers.proto\"\xbf\x04\n\x0bModelConfig\x12\x1e\n\nmodel_name\x18\x01 \x01(\t:\navod_model\x12(\n\x0f\x63heckpoint_name\x18\x02 \x01(\t:\x0f\x64\x65tection_model\x12.\n\x0cpaths_config\x18\x03 \x01(\x0b\x32\x18.avod.protos.PathsConfig\x12.\n\x0cinput_config\x18\x04 \x02(\x0b\x32\x18.avod.protos.InputConfig\x12*\n\nrpn_config\x18\x05 \x02(\x0b\x32\x16.avod.protos.RpnConfig\x12,\n\x0b\x61vod_config\x18\x06 \x02(\x0b\x32\x17.avod.protos.AvodConfig\x12\x1f\n\x17label_smoothing_epsilon\x18\x07 \x02(\x02\x12\x1b\n\x13\x65xpand_proposals_xz\x18\x08 \x02(\x02\x12\x1f\n\x17path_drop_probabilities\x18\t \x03(\x02\x12\x1c\n\x14train_on_all_samples\x18\n \x02(\x08\x12\x18\n\x10\x65val_all_samples\x18\x0b \x02(\x08\x12\x30\n\rlayers_config\x18\x0c \x02(\x0b\x32\x19.avod.protos.LayersConfig\x12,\n\x0bloss_config\x18\r \x02(\x0b\x32\x17.avod.protos.LossConfig\x12\x1d\n\x0eis_adversarial\x18\x0e \x01(\x08:\x05\x66\x61lse\x12\x16\n\x0b\x61\x64v_epsilon\x18\x0f \x01(\x02:\x01\x30\"G\n\x0bPathsConfig\x12\x16\n\x0e\x63heckpoint_dir\x18\x01 \x01(\t\x12\x0e\n\x06logdir\x18\x02 \x01(\t\x12\x10\n\x08pred_dir\x18\x03 \x01(\t\"\x9e\x01\n\x0bInputConfig\x12\x17\n\nbev_dims_h\x18\x01 \x01(\x05:\x03\x37\x30\x30\x12\x17\n\nbev_dims_w\x18\x02 \x01(\x05:\x03\x38\x30\x30\x12\x14\n\tbev_depth\x18\x03 \x01(\x05:\x01\x36\x12\x17\n\nimg_dims_h\x18\x04 \x01(\x05:\x03\x34\x38\x30\x12\x18\n\nimg_dims_w\x18\x05 \x01(\x05:\x04\x31\x35\x39\x30\x12\x14\n\timg_depth\x18\x06 \x01(\x05:\x01\x33\"\x9d\x01\n\tRpnConfig\x12\"\n\x1arpn_proposal_roi_crop_size\x18\x01 \x02(\x05\x12\x19\n\x11rpn_fusion_method\x18\x02 \x02(\t\x12\x1a\n\x12rpn_train_nms_size\x18\x03 \x02(\x05\x12\x19\n\x11rpn_test_nms_size\x18\x04 \x02(\x05\x12\x1a\n\x12rpn_nms_iou_thresh\x18\x05 \x02(\x02\"\xa7\x01\n\nAvodConfig\x12#\n\x1b\x61vod_proposal_roi_crop_size\x18\x01 \x02(\x05\x12\x1f\n\x17\x61vod_positive_selection\x18\x03 \x02(\t\x12\x15\n\ravod_nms_size\x18\x04 \x02(\x05\x12\x1b\n\x13\x61vod_nms_iou_thresh\x18\x05 \x02(\x02\x12\x1f\n\x17\x61vod_box_representation\x18\x06 \x02(\t\"W\n\nLossConfig\x12\x17\n\x0freg_loss_weight\x18\x01 \x02(\x02\x12\x17\n\x0f\x61ng_loss_weight\x18\x02 \x02(\x02\x12\x17\n\x0f\x63ls_loss_weight\x18\x03 \x02(\x02'
   ,
   dependencies=[avod_dot_protos_dot_layers__pb2.DESCRIPTOR,])
 
@@ -133,6 +133,13 @@ _MODELCONFIG = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
+    _descriptor.FieldDescriptor(
+      name='adv_epsilon', full_name='avod.protos.ModelConfig.adv_epsilon', index=14,
+      number=15, type=2, cpp_type=6, label=1,
+      has_default_value=True, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR,  create_key=_descriptor._internal_create_key),
   ],
   extensions=[
   ],
@@ -146,7 +153,7 @@ _MODELCONFIG = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=67,
-  serialized_end=618,
+  serialized_end=642,
 )
 
 
@@ -191,8 +198,8 @@ _PATHSCONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=620,
-  serialized_end=691,
+  serialized_start=644,
+  serialized_end=715,
 )
 
 
@@ -258,8 +265,8 @@ _INPUTCONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=694,
-  serialized_end=852,
+  serialized_start=718,
+  serialized_end=876,
 )
 
 
@@ -318,8 +325,8 @@ _RPNCONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=855,
-  serialized_end=1012,
+  serialized_start=879,
+  serialized_end=1036,
 )
 
 
@@ -378,8 +385,8 @@ _AVODCONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1015,
-  serialized_end=1182,
+  serialized_start=1039,
+  serialized_end=1206,
 )
 
 
@@ -424,8 +431,8 @@ _LOSSCONFIG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1184,
-  serialized_end=1271,
+  serialized_start=1208,
+  serialized_end=1295,
 )
 
 _MODELCONFIG.fields_by_name['paths_config'].message_type = _PATHSCONFIG


### PR DESCRIPTION
Please read the linked issue for context.

To verify that this change does as intended, I ran the `adv-test` target in `run.py` to confirm the code was able to run smoothly.

Closes #33